### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 vtgamma (0.4-5) UNRELEASED; urgency=medium
 
   * Use canonical URL in Vcs-Git.
+  * Update standards version to 4.6.1, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Sat, 10 Sep 2022 08:13:04 -0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+vtgamma (0.4-5) UNRELEASED; urgency=medium
+
+  * Use canonical URL in Vcs-Git.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Sat, 10 Sep 2022 08:13:04 -0000
+
 vtgamma (0.4-4) unstable; urgency=medium
 
   * Fix the watch file, try 2.

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: utils
 Priority: optional
 Maintainer: Adam Borowski <kilobyte@angband.pl>
 Build-Depends: debhelper-compat (= 13)
-Standards-Version: 4.6.0
+Standards-Version: 4.6.1
 Rules-Requires-Root: no
 Homepage: https://github.com/kilobyte/vtgamma
 Vcs-Browser: https://github.com/kilobyte/vtgamma/tree/debian

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Standards-Version: 4.6.0
 Rules-Requires-Root: no
 Homepage: https://github.com/kilobyte/vtgamma
 Vcs-Browser: https://github.com/kilobyte/vtgamma/tree/debian
-Vcs-Git: https://github.com/kilobyte/vtgamma -b debian
+Vcs-Git: https://github.com/kilobyte/vtgamma.git -b debian
 
 Package: vtgamma
 Architecture: all


### PR DESCRIPTION
Fix some issues reported by lintian

* Use canonical URL in Vcs-Git. ([vcs-field-not-canonical](https://lintian.debian.org/tags/vcs-field-not-canonical))

* Update standards version to 4.6.1, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/vtgamma/b917fcf0-7fdf-4d7c-8d9f-da87221f0fed.



These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/b917fcf0-7fdf-4d7c-8d9f-da87221f0fed/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/b917fcf0-7fdf-4d7c-8d9f-da87221f0fed/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/b917fcf0-7fdf-4d7c-8d9f-da87221f0fed/diffoscope)).
